### PR TITLE
updated to deltalake 3.2, added polars

### DIFF
--- a/Dockerfile_delta_quickstart
+++ b/Dockerfile_delta_quickstart
@@ -30,18 +30,20 @@ LABEL authors="Prashanth Babu, Denny Lee, Andrew Bauman, Scott Haines, Tristen W
 
 # Docker image was created and tested with the versions of following packages.
 USER root
-ARG DELTA_SPARK_VERSION="3.1.0"
+ARG DELTA_SPARK_VERSION="3.2.0"
 # Note: for 3.0.0 https://pypi.org/project/deltalake/
-ARG DELTALAKE_VERSION="0.16.4"
+ARG DELTALAKE_VERSION="0.18"
 ARG JUPYTERLAB_VERSION="4.0.7"
 # requires pandas >1.0.5, py4j>=0.10.9.7, pyarrow>=4.0.0
 ARG PANDAS_VERSION="2.2.2"
 ARG ROAPI_VERSION="0.11.1"
 
+ARG POLARS_VERSION="0.20.31"
+
 # We are explicitly pinning the versions of various libraries which this Docker image runs on.
 RUN pip install --quiet --no-cache-dir delta-spark==${DELTA_SPARK_VERSION} \
-deltalake==${DELTALAKE_VERSION} jupyterlab==${JUPYTERLAB_VERSION} pandas==${PANDAS_VERSION} roapi==${ROAPI_VERSION}
-
+deltalake==${DELTALAKE_VERSION} jupyterlab==${JUPYTERLAB_VERSION} pandas==${PANDAS_VERSION} \
+roapi==${ROAPI_VERSION} polars==${POLARS_VERSION} 
 
 # Environment variables
 FROM delta as startup


### PR DESCRIPTION
Updated Delta Lake libraries to version 3.2
Newest spark container still at 3.5.1 but updated 2 days prior
Added polars library to default install

Tested with MPowers Polars Delta integration code

Fixes #10[(https://github.com/delta-io/delta-docker/issues/10)