### PR TITLE
Update Jupyter Lab entrypoint container run commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,12 +206,12 @@ The current version is `delta-spark_2.12:3.0.0` which corresponds to Apache Spar
 
    ```bash
    # Build entry point
-   docker run --name delta_quickstart --rm -it -p 8888-8889:8888-8889 delta_quickstart
+   docker run --name delta_quickstart --rm -it -p 8888-8889:8888-8889 deltaio/delta-docker:latest
    ```
 
    ```bash
    # Image entry point (M1)
-   docker run --name delta_quickstart --rm -it -p 8888-8889:8888-8889 -entrypoint bash deltaio/delta-docker:latest_arm64
+   docker run --name delta_quickstart --rm -it -p 8888-8889:8888-8889 deltaio/delta-docker:latest_arm64
    ```
 
 3. Running the above command gives a JupyterLab notebook URL, copy that URL and launch a browser to follow along the notebook and run each cell.


### PR DESCRIPTION
Tested on osx64 (Intel). The suggested command for the standard container results in the error `Unable to find image 'delta_quickstart:latest' locally` and I believe the image name and tag ought to match what is listed when running `docker image ls`. That is `deltaio/delta-docker:latest`.

The suggested command for Apple Silicon (M1) will start the container but opens a bash shell rather than creating a Jupyter Lab session. I believe the `--entrypoint bash` flag should be removed.