### PR TITLE
Upgrade to delta 4.0.1 (#19)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,6 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@
 # This Docker image uses the official Docker image of [OSS] Apache Spark v4.0.0 as the base container
 # Note: Python version in this image is 3.9.2 and is available as `python3`.
 # Note: PySpark v4.0.0 (https://spark.apache.org/docs/latest/api/python/getting_started/install.html#dependencies)
-ARG BASE_CONTAINER=apache/spark:4.0.0-scala2.13-java17-python3-r-ubuntu
+
+ARG BASE_CONTAINER=apache/spark:4.0.1-scala2.13-java21-python3-r-ubuntu
 FROM $BASE_CONTAINER AS spark
 FROM spark AS delta
 
@@ -30,12 +31,12 @@ LABEL authors="Prashanth Babu, Denny Lee, Andrew Bauman, Scott Haines, Tristen W
 
 # Docker image was created and tested with the following versions of packages.
 USER root
-ARG DELTA_SPARK_VERSION="4.0.0"
+ARG DELTA_SPARK_VERSION="4.0.1"
 # Note: for 3.0.0 https://pypi.org/project/deltalake/
-ARG DELTALAKE_VERSION="1.1.4"
+ARG DELTALAKE_VERSION="1.4.0"
 ARG JUPYTERLAB_VERSION="4.4.6"
 # requires py4j>=0.10.9.7, pyarrow>=16
-ARG POLARS_VERSION="1.33.1"
+ARG POLARS_VERSION="1.37.1"
 ARG PYARROW_VERSION="21.0.0"
 ARG ROAPI_VERSION="0.12.6"
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ You can also download the image from DockerHub at [Delta Lake DockerHub](https:/
 | 1.0.0_3.0.0       | amd64       | 0.12.0 | latest | 3.0.0       | 3.5.0 | 3.6.3      | 1.5.3  | x      | 0.9.0  |
 | 1.0.0_3.0.0_arm64 | arm64       | 0.12.0 | latest | 3.0.0       | 3.5.0 | 3.6.3      | 1.5.3  | x      | 0.9.0  |
 | 4.0.0             | arm64/amd64 | 1.1.14 | 1.1.14 | 4.0.0       | 4.0.0 | 4.4.6      | x      | 1.33.1 | 0.12.6 |
-| latest            | arm64/amd64 | 1.1.14 | 1.1.14 | 4.0.0       | 4.0.0 | 4.4.6      | x      | 1.33.1 | 0.12.6 |
+| 4.0.1             | arm64/amd64 | 1.4.0  | 1.4.0  | 4.0.1       | 4.0.1 | 4.4.6      | x      | 1.33.1 | 0.12.6 |
+| latest            | arm64/amd64 | 1.4.0  | 1.4.0  | 4.0.1       | 4.0.1 | 4.4.6      | x      | 1.37.1 | 0.12.6 |
 
 
 ## Running the Docker environment
@@ -585,9 +586,10 @@ We no longer need to create and maintain separate Dockerfiles for each platform.
 ## Build Locally for Tests
 ```bash
 docker buildx build \
-  --platform linux/amd64,linux/arm64 \
-  -t deltaio_delta-docker:latest 
-  -f Dockerfile
+  --platform linux/arm64 \
+  -t deltaio_delta-docker:latest \
+  -f Dockerfile \
+  --load \
   . 
 ```
 
@@ -597,7 +599,7 @@ docker buildx build \
 # Replace placeholders with your values
 REGISTRY_USERNAME=deltaio
 IMAGE_NAME=delta-docker
-IMAGE_TAG=4.0.0   # e.g., 4.0.0 or latest
+IMAGE_TAG=4.0.1   # e.g., 4.0.1 or latest
 
 docker login
 

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickstart"
-version = "0.1.2"
+version = "0.1.3"
 rust-version = "1.73"
 authors = ["Denny Lee <denny.g.lee@gmail.com>"]
 license = "Apache-2.0"
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 datafusion = "49.0.0"
-deltalake = { version = "0.28.1", features = ["datafusion"] }
+deltalake = { version = "1.4.0", features = ["datafusion"] }
 tokio = { version = "1" }
 
 [[example]]

--- a/startup.sh
+++ b/startup.sh
@@ -4,7 +4,7 @@ source "$HOME/.cargo/env"
 
 export PYSPARK_DRIVER_PYTHON=jupyter
 export PYSPARK_DRIVER_PYTHON_OPTS='lab --ip=0.0.0.0'
-export DELTA_SPARK_VERSION='4.0.0'
+export DELTA_SPARK_VERSION='4.0.1'
 export DELTA_PACKAGE_VERSION=delta-spark_2.13:${DELTA_SPARK_VERSION}
 
 $SPARK_HOME/bin/pyspark --packages io.delta:${DELTA_PACKAGE_VERSION} \


### PR DESCRIPTION
upgraded the base Docker image to include current versions of Delta (4.0.1), delta-rs (1.4.0), and the compatible runtimes (spark 4.0.1, java 21, etc)