### PR TITLE
Update Readme to consistently use the same Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ The current version is `delta-spark_2.13:4.0.0` which corresponds to Apache Spar
       --rm \
       -it \
       -p 8888-8889:8888-8889 \
-      delta_quickstart
+      deltaio/delta-docker:latest
     ```
 
 3. Running the above command gives a JupyterLab notebook URL. Copy that URL and launch a browser to follow along with the notebook and run each cell.


### PR DESCRIPTION
The Readme was pointing to the wrong Docker Image even though it had the correct image. `delta_quickstart` image doesn't exist anymore. The Readme has already been updated above, this was probably a straggler.


