### PR TITLE
Upgrade deltalake and datafusion dependencies

### DIFF
--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -9,9 +9,10 @@ description = "Quick Start Delta Lake Rust examples"
 edition = "2021"
 
 [dependencies]
-datafusion = "49.0.0"
-deltalake = { version = "0.28.0", features = ["datafusion"] }
+datafusion = "53.1.0"
+deltalake = { version = "0.32.4", features = ["datafusion"] }
 tokio = { version = "1" }
+url = "2.5"
 
 [[example]]
 name = "read_delta_table"

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 datafusion = "49.0.0"
-deltalake = { version = "1.4.0", features = ["datafusion"] }
+deltalake = { version = "0.28.0", features = ["datafusion"] }
 tokio = { version = "1" }
 
 [[example]]

--- a/rs/examples/read_delta_datafusion.rs
+++ b/rs/examples/read_delta_datafusion.rs
@@ -1,11 +1,13 @@
 use datafusion::execution::context::SessionContext;
-use std::sync::Arc;
 use deltalake;
+use std::sync::Arc;
+use url::Url;
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), deltalake::DeltaTableError>  {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // This table is included in the Rust example
-    let table_path = "data/COVID-19_NYT";
+    let table_path = Url::from_file_path(std::fs::canonicalize("data/COVID-19_NYT")?)
+        .expect("Invalid file path");
 
     // datafusion SessionContext
     let ctx = SessionContext::new();
@@ -13,7 +15,11 @@ async fn main() -> Result<(), deltalake::DeltaTableError>  {
         .await?;
 
     // register table via `datafusion`
-    ctx.register_table("covid19_nyt", Arc::new(delta_table)).unwrap();
+    ctx.register_table(
+        "covid19_nyt",
+        Arc::new(delta_table.table_provider().build().await?),
+    )
+    .unwrap();
 
     // Query table via datafusion
     let batches = ctx

--- a/rs/examples/read_delta_table.rs
+++ b/rs/examples/read_delta_table.rs
@@ -1,7 +1,9 @@
+use url::Url;
+
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), deltalake::DeltaTableError> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // This table is included in the Rust example
-    let table_path = "data/COVID-19_NYT";
+    let table_path = Url::from_directory_path(std::fs::canonicalize("data/COVID-19_NYT")?).unwrap();
 
     // Get Delta table metadata
     let table = deltalake::open_table(table_path).await?;


### PR DESCRIPTION
This changeset addresses issue #26 by changing the version of the `deltalake` dependency in `rs/Cargo.toml`. The `deltalake` and `datafusion` dependencies are updated to more recent versions.

The first commit in this pull request rolls back a change made to `rs/Cargo.toml` that upgraded the `deltalake` dependency to version 1.4.0 (a version which, as far as I can tell, doesn’t exist). This change resolves the issue described in #26.

The second commit in this pull request brings `deltalake` up to the latest version (and upgrades `datafusion` to the latest one supported by `deltalake`). Some changes are made to the rust examples to accommodate API evolutions in these crates.

Maintainer, I explicitly invite extra scrutiny on the changes I made to `‌read_delta_datafusion.rs` and `‌read_delta_table.rs`. I am not (yet) skilled in the use of deltalake, and it’s possible that I made a mistake. I made these changes so that I could follow along in the O’Reilly textbook, and I hope I can pay it forward to future learners! With that being said, manual testing of these changes produced the exact results that are provided as examples in `README.md`, and so I am reasonably confident that they’re correct.

Resolves #26.