### PR TITLE
upgrade to delta 4.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ LABEL authors="Prashanth Babu, Denny Lee, Andrew Bauman, Scott Haines, Tristen W
 
 # Docker image was created and tested with the following versions of packages.
 USER root
-ARG DELTA_SPARK_VERSION="4.2.0"
+ARG DELTA_SPARK_VERSION="4.3.0"
 # Note: for 3.0.0 https://pypi.org/project/deltalake/
 ARG DELTALAKE_VERSION="1.6.2"
 ARG JUPYTERLAB_VERSION="4.6.2"

--- a/README.md
+++ b/README.md
@@ -47,13 +47,12 @@ You can also download the image from DockerHub at [Delta Lake DockerHub](https:/
 
 | Tag               | Platform    | Python | Rust   | Delta-Spark | Spark | JupyterLab | Pandas | Polars | ROAPI  |
 |-------------------|-------------|--------|--------|-------------|-------|------------|--------|--------|--------|
-| 1.0.0_3.0.0       | amd64       | 0.12.0 | latest | 3.0.0       | 3.5.0 | 3.6.3      | 1.5.3  | x      | 0.9.0  |
-| 1.0.0_3.0.0_arm64 | arm64       | 0.12.0 | latest | 3.0.0       | 3.5.0 | 3.6.3      | 1.5.3  | x      | 0.9.0  |
 | 4.0.0             | arm64/amd64 | 1.1.14 | 1.1.14 | 4.0.0       | 4.0.0 | 4.4.6      | x      | 1.33.1 | 0.12.6 |
 | 4.0.1             | arm64/amd64 | 1.4.0  | 1.4.0  | 4.0.1       | 4.0.1 | 4.4.6      | x      | 1.33.1 | 0.12.6 |
 | 4.1.0             | arm64/amd64 | 1.4.0  | 1.4.0  | 4.1.0       | 4.1.0 | 4.4.6      | x      | 1.33.1 | 0.12.6 |
 | 4.2.0             | arm64/amd64 | 1.6.2  | 1.6.2  | 4.2.0       | 4.2.0 | 4.6.2      | x      | 1.43.2 | 0.12.7 |
-| latest            | arm64/amd64 | 1.6.2  | 1.6.2  | 4.2.0       | 4.2.0 | 4.6.2      | x      | 1.43.2 | 0.12.7 |
+| 4.3.0             | arm64/amd64 | 1.6.2  | 1.6.2  | 4.3.0       | 4.1.1 | 4.6.2      | x      | 1.43.2 | 0.12.7 |
+| latest            | arm64/amd64 | 1.6.2  | 1.6.2  | 4.3.0       | 4.1.1 | 4.6.2      | x      | 1.43.2 | 0.12.7 |
 
 
 ## Running the Docker environment
@@ -83,7 +82,7 @@ Once the image has been built or you have downloaded the correct image, you can 
 
 In the following instructions, the variable `${DELTA_PACKAGE_VERSION}` refers to the Delta Lake Package version.
 
-The current version is `delta-spark_2.13:4.2.0` which corresponds to Apache Spark 4.x release line.
+The current version is `delta-spark_2.13:4.3.0` which corresponds to Apache Spark 4.x release line.
 
 ## Choose an Interface
 

--- a/development.md
+++ b/development.md
@@ -21,7 +21,7 @@ docker buildx build \
   --platform linux/arm64 \
   -t deltaio_delta-docker:latest \
   -f Dockerfile \
-  --build-arg PYPI_PROXY_URL=https://pypi-proxy.dev.databricks.com/simple/ \
+  --build-arg PYPI_PROXY_URL=https://pypi-proxy.your-company.com/simple/ \
   --load \
   .
 ```

--- a/development.md
+++ b/development.md
@@ -34,7 +34,7 @@ docker buildx build \
 
 ```bash
 $DOCKER_USER=deltaio
-$VERSION=4.2.0
+$VERSION=4.3.0
 
 echo "${DOCKER_USER}/delta-docker:${VERSION}"
 
@@ -53,7 +53,7 @@ Build without the cache only if you want to rebuild the full image from scratch.
 
 ```bash
 $DOCKER_USER=deltaio
-$VERSION=4.2.0
+$VERSION=4.3.0
 docker buildx build \
   --no-cache \
   --platform linux/amd64,linux/arm64 \

--- a/startup.sh
+++ b/startup.sh
@@ -4,7 +4,7 @@ source "$HOME/.cargo/env"
 
 export PYSPARK_DRIVER_PYTHON=jupyter
 export PYSPARK_DRIVER_PYTHON_OPTS='lab --ip=0.0.0.0'
-export DELTA_SPARK_VERSION='4.2.0'
+export DELTA_SPARK_VERSION='4.3.0'
 export SPARK_VERSION='4.1'
 export DELTA_PACKAGE_VERSION=delta-spark_${SPARK_VERSION}_2.13:${DELTA_SPARK_VERSION}
 export MAVEN_PROXY_URL=${MAVEN_PROXY_URL:-https://repo.1.maven.org/maven2/}

--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -136,7 +136,7 @@ section "Python Package Versions"
 run_test "delta-spark version matches Dockerfile ARG" \
   "python3 -c \"
 import delta
-expected = '4.2.0'
+expected = '4.3.0'
 actual = delta.__version__
 assert actual == expected, f'Expected {expected}, got {actual}'
 \""


### PR DESCRIPTION
This PR is based off of the work to upgrade to Delta 4.2.0. The only changes here are the delta-spark version, docker tests, and README.md.