### PR TITLE
upgraded to delta-spark 4.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ LABEL authors="Prashanth Babu, Denny Lee, Andrew Bauman, Scott Haines, Tristen W
 
 # Docker image was created and tested with the following versions of packages.
 USER root
-ARG DELTA_SPARK_VERSION="4.3.0"
+ARG DELTA_SPARK_VERSION="4.3.1"
 # Note: for 3.0.0 https://pypi.org/project/deltalake/
 ARG DELTALAKE_VERSION="1.6.2"
 ARG JUPYTERLAB_VERSION="4.6.2"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ You can also download the image from DockerHub at [Delta Lake DockerHub](https:/
 | 4.1.0             | arm64/amd64 | 1.4.0  | 1.4.0  | 4.1.0       | 4.1.0 | 4.4.6      | x      | 1.33.1 | 0.12.6 |
 | 4.2.0             | arm64/amd64 | 1.6.2  | 1.6.2  | 4.2.0       | 4.2.0 | 4.6.2      | x      | 1.43.2 | 0.12.7 |
 | 4.3.0             | arm64/amd64 | 1.6.2  | 1.6.2  | 4.3.0       | 4.1.1 | 4.6.2      | x      | 1.43.2 | 0.12.7 |
-| latest            | arm64/amd64 | 1.6.2  | 1.6.2  | 4.3.0       | 4.1.1 | 4.6.2      | x      | 1.43.2 | 0.12.7 |
+| 4.3.1             | arm64/amd64 | 1.6.2  | 1.6.2  | 4.3.1       | 4.1.1 | 4.6.2      | x      | 1.43.2 | 0.12.7 |
+| latest            | arm64/amd64 | 1.6.2  | 1.6.2  | 4.3.1       | 4.1.1 | 4.6.2      | x      | 1.43.2 | 0.12.7 |
 
 
 ## Running the Docker environment
@@ -82,7 +83,7 @@ Once the image has been built or you have downloaded the correct image, you can 
 
 In the following instructions, the variable `${DELTA_PACKAGE_VERSION}` refers to the Delta Lake Package version.
 
-The current version is `delta-spark_2.13:4.3.0` which corresponds to Apache Spark 4.x release line.
+The current version is `delta-spark_2.13:4.3.1` which corresponds to Apache Spark 4.x release line.
 
 ## Choose an Interface
 

--- a/development.md
+++ b/development.md
@@ -53,7 +53,7 @@ Build without the cache only if you want to rebuild the full image from scratch.
 
 ```bash
 $DOCKER_USER=deltaio
-$VERSION=4.3.0
+$VERSION=4.3.1
 docker buildx build \
   --no-cache \
   --platform linux/amd64,linux/arm64 \

--- a/development.md
+++ b/development.md
@@ -34,7 +34,7 @@ docker buildx build \
 
 ```bash
 $DOCKER_USER=deltaio
-$VERSION=4.3.0
+$VERSION=4.3.1
 
 echo "${DOCKER_USER}/delta-docker:${VERSION}"
 

--- a/startup.sh
+++ b/startup.sh
@@ -4,7 +4,7 @@ source "$HOME/.cargo/env"
 
 export PYSPARK_DRIVER_PYTHON=jupyter
 export PYSPARK_DRIVER_PYTHON_OPTS='lab --ip=0.0.0.0'
-export DELTA_SPARK_VERSION='4.3.0'
+export DELTA_SPARK_VERSION='4.3.1'
 export SPARK_VERSION='4.1'
 export DELTA_PACKAGE_VERSION=delta-spark_${SPARK_VERSION}_2.13:${DELTA_SPARK_VERSION}
 export MAVEN_PROXY_URL=${MAVEN_PROXY_URL:-https://repo.1.maven.org/maven2/}

--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -132,6 +132,9 @@ run_test "jupyterlab imports cleanly"   "python3 -c 'import jupyterlab'"
 # 4. Python package versions
 # ---------------------------------------------------------------
 
+# > note: the 4.3.1 release didn't bump the version.py (https://github.com/delta-io/delta/blob/v4.3.1/python/delta/version.py)
+# > so we're using the 4.3.0 version even though it is technically 4.3.1.
+
 section "Python Package Versions"
 run_test "delta-spark version matches Dockerfile ARG" \
   "python3 -c \"


### PR DESCRIPTION
This is a fairly basic upgrade. The only call out is that in the `test_docker.sh` I had to keep the pin at 4.3.0 for the version test since the python package didn't bump to 4.3.1 (https://github.com/delta-io/delta/blob/v4.3.1/python/delta/version.py) - this is called out in the comment.