### PR TITLE
upgraded the docker environment to delta 4.4.0, spark 4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,11 @@
 # Dockerfile for Delta Lake quickstart
 # ------------------------------------------------
 
-# This Docker image uses the official Docker image of [OSS] Apache Spark v4.0.0 as the base container
-# Note: Python version in this image is 3.9.2 and is available as `python3`.
-# Note: PySpark v4.0.0 (https://spark.apache.org/docs/latest/api/python/getting_started/install.html#dependencies)
+# This Docker image uses the official Docker image of [OSS] Apache Spark v4.2.0 as the base container
+# Note: Python version in this image is 3.10.12 and is available as `python3`.
+# Note: PySpark v4.2.0 (https://spark.apache.org/docs/latest/api/python/getting_started/install.html#dependencies)
 
-ARG BASE_CONTAINER=apache/spark:4.1.1-scala2.13-java21-python3-r-ubuntu
+ARG BASE_CONTAINER=apache/spark:4.2.0-java21-python3
 FROM $BASE_CONTAINER AS spark
 FROM spark AS delta
 
@@ -31,8 +31,7 @@ LABEL authors="Prashanth Babu, Denny Lee, Andrew Bauman, Scott Haines, Tristen W
 
 # Docker image was created and tested with the following versions of packages.
 USER root
-ARG DELTA_SPARK_VERSION="4.3.1"
-# Note: for 3.0.0 https://pypi.org/project/deltalake/
+ARG DELTA_SPARK_VERSION="4.4.0"
 ARG DELTALAKE_VERSION="1.6.2"
 ARG JUPYTERLAB_VERSION="4.6.2"
 # requires py4j>=0.10.9.7, pyarrow>=16

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ You can also download the image from DockerHub at [Delta Lake DockerHub](https:/
 | 4.2.0             | arm64/amd64 | 1.6.2  | 1.6.2  | 4.2.0       | 4.2.0 | 4.6.2      | x      | 1.43.2 | 0.12.7 |
 | 4.3.0             | arm64/amd64 | 1.6.2  | 1.6.2  | 4.3.0       | 4.1.1 | 4.6.2      | x      | 1.43.2 | 0.12.7 |
 | 4.3.1             | arm64/amd64 | 1.6.2  | 1.6.2  | 4.3.1       | 4.1.1 | 4.6.2      | x      | 1.43.2 | 0.12.7 |
-| latest            | arm64/amd64 | 1.6.2  | 1.6.2  | 4.3.1       | 4.1.1 | 4.6.2      | x      | 1.43.2 | 0.12.7 |
+| 4.4.0             | arm64/amd64 | 1.6.2  | 1.6.2  | 4.4.0       | 4.2.0 | 4.6.2      | x      | 1.43.2 | 0.12.7 |
+| latest            | arm64/amd64 | 1.6.2  | 1.6.2  | 4.4.0       | 4.2.0 | 4.6.2      | x      | 1.43.2 | 0.12.7 |
 
 
 ## Running the Docker environment
@@ -83,7 +84,7 @@ Once the image has been built or you have downloaded the correct image, you can 
 
 In the following instructions, the variable `${DELTA_PACKAGE_VERSION}` refers to the Delta Lake Package version.
 
-The current version is `delta-spark_2.13:4.3.1` which corresponds to Apache Spark 4.x release line.
+The current version is `delta-spark_2.13:4.4.0` which corresponds to Apache Spark 4.x release line.
 
 ## Choose an Interface
 

--- a/development.md
+++ b/development.md
@@ -34,7 +34,7 @@ docker buildx build \
 
 ```bash
 $DOCKER_USER=deltaio
-$VERSION=4.3.1
+$VERSION=4.4.0
 
 echo "${DOCKER_USER}/delta-docker:${VERSION}"
 
@@ -53,7 +53,7 @@ Build without the cache only if you want to rebuild the full image from scratch.
 
 ```bash
 $DOCKER_USER=deltaio
-$VERSION=4.3.1
+$VERSION=4.4.0
 docker buildx build \
   --no-cache \
   --platform linux/amd64,linux/arm64 \

--- a/quickstart.ipynb
+++ b/quickstart.ipynb
@@ -69,7 +69,7 @@
     {
      "data": {
       "text/plain": [
-       "'4.1.1'"
+       "'4.2.0'"
       ]
      },
      "execution_count": 2,

--- a/startup.sh
+++ b/startup.sh
@@ -4,13 +4,18 @@ source "$HOME/.cargo/env"
 
 export PYSPARK_DRIVER_PYTHON=jupyter
 export PYSPARK_DRIVER_PYTHON_OPTS='lab --ip=0.0.0.0'
-export DELTA_SPARK_VERSION='4.3.1'
-export SPARK_VERSION='4.1'
+export DELTA_SPARK_VERSION='4.4.0'
+export SPARK_VERSION='4.2'
 export DELTA_PACKAGE_VERSION=delta-spark_${SPARK_VERSION}_2.13:${DELTA_SPARK_VERSION}
-export MAVEN_PROXY_URL=${MAVEN_PROXY_URL:-https://repo.1.maven.org/maven2/}
+export MAVEN_PROXY_URL=${MAVEN_PROXY_URL:}
+
+REPOSITORIES_CONF=()
+if [ -n "$MAVEN_PROXY_URL" ]; then
+  REPOSITORIES_CONF=(--conf "spark.jars.repositories=${MAVEN_PROXY_URL}")
+fi
 
 $SPARK_HOME/bin/pyspark --packages io.delta:${DELTA_PACKAGE_VERSION} \
-  --conf "spark.jars.repositories=${MAVEN_PROXY_URL}" \
+  "${REPOSITORIES_CONF[@]}" \
   --conf "spark.driver.extraJavaOptions=-Divy.cache.dir=/tmp -Divy.home=/tmp -Dio.netty.tryReflectionSetAccessible=true" \
   --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
   --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"

--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -132,14 +132,11 @@ run_test "jupyterlab imports cleanly"   "python3 -c 'import jupyterlab'"
 # 4. Python package versions
 # ---------------------------------------------------------------
 
-# > note: the 4.3.1 release didn't bump the version.py (https://github.com/delta-io/delta/blob/v4.3.1/python/delta/version.py)
-# > so we're using the 4.3.0 version even though it is technically 4.3.1.
-
 section "Python Package Versions"
 run_test "delta-spark version matches Dockerfile ARG" \
   "python3 -c \"
 import delta
-expected = '4.3.0'
+expected = '4.4.0'
 actual = delta.__version__
 assert actual == expected, f'Expected {expected}, got {actual}'
 \""


### PR DESCRIPTION
updated docs and tests
- added better startup.sh support for empty maven_proxy_url. This was causing an issue since repo1 in maven central will sometimes fail, and it can cause the jupyter log to print a lot of warnings. This can feel like things aren't working (even when the environment is working as expected)